### PR TITLE
GUI - Set rate limiting for the nginx server

### DIFF
--- a/simple-paste-client/nginx.conf
+++ b/simple-paste-client/nginx.conf
@@ -1,23 +1,31 @@
+limit_req_zone $binary_remote_addr zone=basiclimit:10m rate=10r/s;
+
 upstream simple-paste-api {
   server simple-paste-api:3000;
 }
 
 server {
-  listen 80;
+  listen 80 default_server;
+  server_name simple-paste.com www.simple-paste.com
 
   location / {
+    limit_req zone=basiclimit burst=5 nodelay;
+    
     root /usr/share/nginx/html;
     index index.html index.htm;
     try_files $uri $uri/ /index.html;
   }
 
   location /api/ {
+    limit_req zone=basiclimit burst=5 nodelay;
+    
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Simple-Paste $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Host $server_name;
+    proxy_set_header X-Request-Id $request_id;
     proxy_pass http://simple-paste-api/;
   }
 }


### PR DESCRIPTION
Things done in this pull request:

- Set server name and specify the `default_server`
- Configure a rate limiting for both front service and API proxy
